### PR TITLE
Ignore annotation processor warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Xlint:all</arg>
+            <arg>-Xlint:-processing</arg>
             <arg>-Werror</arg>
           </compilerArgs>
         </configuration>


### PR DESCRIPTION
The maven build action is failing due to annotation processor warnings, which should not cause it to fail.